### PR TITLE
Add download button for GitHub

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,16 @@
 {
-	"presets": [
-		"@babel/preset-env"
-	],
+	"env": {
+		"test": {
+			"presets": [
+				"@babel/preset-env"
+			],
+			"plugins": [
+				"@babel/plugin-transform-react-jsx",
+				"@babel/plugin-transform-runtime"
+			]
+		}
+	},
 	"plugins": [
-		"@babel/plugin-transform-react-jsx",
-		"@babel/plugin-transform-runtime"
+		"@babel/plugin-transform-react-jsx"
 	]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,7 @@
 		"@babel/preset-env"
 	],
 	"plugins": [
-		"@babel/plugin-transform-react-jsx"
+		"@babel/plugin-transform-react-jsx",
+		"@babel/plugin-transform-runtime"
 	]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,8 @@
+{
+	"presets": [
+		"@babel/preset-env"
+	],
+	"plugins": [
+		"@babel/plugin-transform-react-jsx"
+	]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,33 @@
 {
-	"extends": "@martin-kolarik/eslint-config"
+	"parser": "babel-eslint",
+	"parserOptions": {
+		"sourceType": "module",
+		"ecmaFeatures": {
+			"jsx": true
+		}
+	},
+	"extends": "@martin-kolarik/eslint-config",
+	"overrides": [
+		{
+			"files": [
+				"src/**/*.js",
+				"test/**/*.js"
+			],
+			"rules": {
+				"no-unused-vars": [
+					"error",
+					{
+						"varsIgnorePattern": "^React$"
+					}
+				],
+				"no-extra-parens": [
+					"error",
+					"all",
+					{
+						"ignoreJSX": "multi-line"
+					}
+				]
+			}
+		}
+	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -654,6 +654,18 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.2.tgz",
+      "integrity": "sha512-cqULw/QB4yl73cS5Y0TZlQSjDvNkzDbu0FurTZyHlJpWE5T3PCMdnyV+xXoH1opr1ldyHODe3QAX3OMAii5NxA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -781,6 +793,15 @@
         "mkdirp": "^0.5.1",
         "pirates": "^4.0.0",
         "source-map-support": "^0.5.9"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
+      "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
       }
     },
     "@babel/template": {
@@ -6245,6 +6266,12 @@
       "requires": {
         "regenerate": "^1.4.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,6 +66,16 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-builder-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-MjA9KgwCuPEkQd9ncSXvSyJ5y+j2sICHyrI0M3L+6fnS4wMSNDc1ARXsbTfbb2cXHn17VisSnU/sHFTCxVxSMw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.0",
+        "esutils": "^2.0.0"
+      }
+    },
     "@babel/helper-call-delegate": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-call-delegate/-/helper-call-delegate-7.4.4.tgz",
@@ -356,6 +366,15 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-syntax-jsx": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz",
+      "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.2.0.tgz",
@@ -606,6 +625,17 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-react-jsx": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz",
+      "integrity": "sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-react-jsx": "^7.3.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-jsx": "^7.2.0"
+      }
+    },
     "@babel/plugin-transform-regenerator": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.4.5.tgz",
@@ -738,6 +768,19 @@
         "invariant": "^2.2.2",
         "js-levenshtein": "^1.1.3",
         "semver": "^5.5.0"
+      }
+    },
+    "@babel/register": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.6.2.tgz",
+      "integrity": "sha512-xgZk2LRZvt6i2SAUWxc7ellk4+OYRgS3Zpsnr13nMS1Qo25w21Uu8o6vTOAqNaxiqrnv30KTYzh9YWY2k21CeQ==",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.13",
+        "mkdirp": "^0.5.1",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.9"
       }
     },
     "@babel/template": {
@@ -1162,8 +1205,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-      "dev": true
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -1242,6 +1284,12 @@
         }
       }
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1289,6 +1337,20 @@
       "requires": {
         "follow-redirects": "1.5.10",
         "is-buffer": "^2.0.2"
+      }
+    },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
       }
     },
     "babel-loader": {
@@ -1452,6 +1514,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "browserify-aes": {
@@ -1671,6 +1739,20 @@
       "integrity": "sha512-fpZ81yYfzentuieinmGnphk0pLkOTMm6MZdVqwd77ROvhko6iujLNGrHH5E7utq3ygWklwfmwuG+A7P+NpqT6w==",
       "dev": true
     },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
+    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1710,6 +1792,12 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
     },
     "chokidar": {
@@ -2155,6 +2243,15 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2227,6 +2324,12 @@
       "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
     "diffie-hellman": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
@@ -2255,6 +2358,20 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-chef": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/dom-chef/-/dom-chef-3.6.2.tgz",
+      "integrity": "sha512-vT8IYkzIXDET7gplO+U4XCctBadIOX2SsVr4WSt6pUjrBOdVQGYWIVjArnhxbqA+6sHKgjXR31iNsRv+1Tk6uA==",
+      "requires": {
+        "arr-flatten": "^1.0.3",
+        "svg-tag-names": "^1.1.1"
+      }
+    },
+    "dom-loaded": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-loaded/-/dom-loaded-2.0.0.tgz",
+      "integrity": "sha512-sbtlB2ZM+HnKf4fV0nmuxrxY7hKE1vNmgcSD5l3io5ZK+OUBynJxONU5mJffri7nE9/ID34nN+BrN4OSONf8qw=="
     },
     "dom-serializer": {
       "version": "0.2.1",
@@ -2543,6 +2660,12 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-chai-expect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-expect/-/eslint-plugin-chai-expect-2.0.1.tgz",
+      "integrity": "sha512-HiFoh9F9grVdVQEIwADwPA7SlcGZcsm9gdzZGDoH2SeUoUmYrUuq1cQmfjyOfqRpFOL6qlhcz5nZW2ppTH9ZlQ==",
+      "dev": true
     },
     "eslint-plugin-es": {
       "version": "2.0.0",
@@ -2996,6 +3119,15 @@
         "is-glob": "^4.0.0",
         "micromatch": "^3.0.4",
         "resolve-dir": "^1.0.1"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
       }
     },
     "flat-cache": {
@@ -3671,6 +3803,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-stdin": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
@@ -3825,6 +3963,12 @@
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
       "dev": true
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "dev": true
+    },
     "gzip-size": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.1.1.tgz",
@@ -3913,6 +4057,12 @@
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
       }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
@@ -4940,6 +5090,116 @@
         }
       }
     },
+    "mocha": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.1.tgz",
+      "integrity": "sha512-VCcWkLHwk79NYQc8cxhkmI8IigTIhsCwZ6RTxQsqK6go4UvEhzJkYuHm8B2YtlSxcYq2fY+ucr4JBwoD6ci80A==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
+      }
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -5010,6 +5270,16 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      }
+    },
     "node-libs-browser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
@@ -5048,6 +5318,12 @@
           "dev": true
         }
       }
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
     },
     "node-releases": {
       "version": "1.1.32",
@@ -5452,6 +5728,12 @@
         }
       }
     },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -5476,6 +5758,15 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
     },
     "pkg-dir": {
       "version": "3.0.0",
@@ -6992,6 +7283,11 @@
         "has-flag": "^3.0.0"
       }
     },
+    "svg-tag-names": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/svg-tag-names/-/svg-tag-names-1.1.2.tgz",
+      "integrity": "sha512-LIDOy8NRLGfJegTEnpizWA/ofg3Gyx58JgPEEjvATFciUJW9dHZ2aPTYY0Mn2rQYCeUGZElpHfu91OcWK0IMIw=="
+    },
     "svg-tags": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
@@ -7227,6 +7523,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
@@ -7660,6 +7962,42 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -7752,6 +8090,37 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
+      },
+      "dependencies": {
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,26 +5,38 @@
 	"scripts": {
 		"lint": "npm run lint:css && npm run lint:js",
 		"lint:css": "stylelint \"./src/**/*.css\"",
-		"lint:js": "eslint --ext .js src",
+		"lint:js": "eslint --ext .js src test",
 		"watch": "webpack --mode=development --watch",
-		"build": "webpack --mode=production"
+		"build": "webpack --mode=production",
+		"mocha": "mocha --require @babel/register test/**/*.js",
+		"test": "npm run lint && npm run mocha"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.6.2",
+		"@babel/plugin-transform-react-jsx": "^7.3.0",
 		"@babel/preset-env": "^7.6.2",
+		"@babel/register": "^7.6.2",
 		"@martin-kolarik/eslint-config": "^2.0.0",
 		"@martin-kolarik/stylelint-config": "^1.0.1",
+		"babel-eslint": "^10.0.3",
 		"babel-loader": "^8.0.6",
+		"chai": "^4.2.0",
 		"copy-webpack-plugin": "^5.0.4",
 		"css-loader": "^3.2.0",
 		"eslint": "^6.4.0",
+		"eslint-plugin-chai-expect": "^2.0.1",
 		"eslint-plugin-html": "^6.0.0",
 		"eslint-plugin-node": "^10.0.0",
 		"eslint-plugin-promise": "^4.2.1",
 		"mini-css-extract-plugin": "^0.8.0",
+		"mocha": "^6.2.1",
 		"size-plugin": "^2.0.0",
 		"stylelint": "^11.0.0",
 		"webpack": "^4.41.0",
 		"webpack-cli": "^3.3.9"
+	},
+	"dependencies": {
+		"dom-chef": "^3.6.2",
+		"dom-loaded": "^2.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
 	"devDependencies": {
 		"@babel/core": "^7.6.2",
 		"@babel/plugin-transform-react-jsx": "^7.3.0",
+		"@babel/plugin-transform-runtime": "^7.6.2",
 		"@babel/preset-env": "^7.6.2",
 		"@babel/register": "^7.6.2",
+		"@babel/runtime": "^7.6.2",
 		"@martin-kolarik/eslint-config": "^2.0.0",
 		"@martin-kolarik/stylelint-config": "^1.0.1",
 		"babel-eslint": "^10.0.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"lint:js": "eslint --ext .js src test",
 		"watch": "webpack --mode=development --watch",
 		"build": "webpack --mode=production",
-		"mocha": "mocha --require @babel/register test/**/*.js",
+		"mocha": "NODE_ENV=test mocha --require @babel/register test/**/*.js",
 		"test": "npm run lint && npm run mocha"
 	},
 	"devDependencies": {

--- a/src/features/github-download-button.css
+++ b/src/features/github-download-button.css
@@ -1,3 +1,22 @@
-.jsd-btn-orange {
-	background-color: #ff5627;
+.jsd-btn-orange.btn {
+	color: #fff;
+	background-color: #dc6413;
+	background-image: linear-gradient(-180deg, #fb8b6b, #dc6413 90%);
+}
+
+.jsd-btn-orange.btn:hover {
+	background-color: #da691d;
+	background-image: linear-gradient(-180deg, #ff9476, #da691d 90%);
+	border-color: rgba(27, 31, 35, .5);
+}
+
+[open] > .jsd-btn-orange.btn {
+	background-color: #e66309;
+	background-image: none;
+	border-color: rgba(27, 31, 35, .4);
+	box-shadow: inset 0 .15em .3em rgba(27, 31, 35, .05);
+}
+
+.jsd-flash.flash {
+	padding: 10px;
 }

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import onDomReady from 'dom-loaded';
 
 import { isGitHub, isRepoRoot } from '../libs/page-detect';
-import { getRepoDetails } from '../libs/utils';
+import { getRepoDetails, hasJSExtension } from '../libs/utils';
 import { clippy } from '../libs/icons';
 
 import './github-download-button.css';
@@ -37,7 +37,9 @@ async function init () {
 				const packageFilesResponse = await fetch(packageFilesUrl);
 				const { default: defaultFile } = await packageFilesResponse.json();
 
-				const cdnUrl = defaultFile ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
+				// Validate file name, since `bootstrap`
+				// has default file name without `.js` extension
+				const cdnUrl = defaultFile && hasJSExtension(defaultFile) ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
 
 				const menu = (
 					<details class="jsd-get-repo-select-menu dropdown details-reset details-overlay">

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -73,11 +73,29 @@ async function init () {
 												</div>
 											)
 											: (
-												<div class="flash flash-warn my-2 jsd-flash">
+												<div class="flash flash-warn mt-2 jsd-flash">
 													Sadly, this package doesn't have a default file set.
 												</div>
 											)
 										}
+									</div>
+									<div class="mt-2">
+										<a
+											class="btn btn-outline get-repo-btn tooltipped tooltipped-s tooltipped-multiline"
+											href={`https://www.jsdelivr.com/package/npm/${name}`}
+											target="_blank"
+											rel="nofollow"
+											aria-label={`Open ${ownerName}/${repoName} in jsDelivr website and select the files you want to use.`}
+										>
+											Open in jsDelivr
+										</a>
+										<a
+											class="btn btn-outline get-repo-btn"
+											href={`https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`}
+											rel="nofollow"
+										>
+											Download ZIP
+										</a>
 									</div>
 								</div>
 							</div>

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -21,11 +21,17 @@ async function init () {
 
 				const rawPackageUrl = `https://raw.githubusercontent.com/${ownerName}/${repoName}/${treeName}/package.json`;
 				const rawPackageResponse = await fetch(rawPackageUrl);
-				const { name, version } = await rawPackageResponse.json();
+				const { name } = await rawPackageResponse.json();
 
-				if (!name && !version) {
+				if (!name) {
 					return;
 				}
+
+				const packageVersionsUrl = `https://data.jsdelivr.com/v1/package/npm/${name}`;
+				const packageVersionsResponse = await fetch(packageVersionsUrl);
+				const { tags, versions } = await packageVersionsResponse.json();
+
+				const version = tags.latest ? tags.latest : versions[0];
 
 				const packageFilesUrl = `https://data.jsdelivr.com/v1/package/npm/${name}@${version}`;
 				const packageFilesResponse = await fetch(packageFilesUrl);

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -1,3 +1,102 @@
+import React from 'dom-chef';
+import onDomReady from 'dom-loaded';
+
+import { isGitHub, isRepoRoot } from '../libs/page-detect';
+import { getRepoDetails } from '../libs/utils';
+import { clippy } from '../libs/icons';
+
 import './github-download-button.css';
 
-console.log('🚧 jsDelivr Extension 🚧');
+async function init () {
+	await onDomReady;
+
+	if (isGitHub()) {
+		if (isRepoRoot()) {
+			try {
+				const { ownerName, repoName, treeName } = getRepoDetails();
+
+				const rawPackageUrl = `https://raw.githubusercontent.com/${ownerName}/${repoName}/${treeName}/package.json`;
+				const rawPackageResponse = await fetch(rawPackageUrl);
+				const { name, version } = await rawPackageResponse.json();
+
+				if (!name && !version) {
+					return;
+				}
+
+				const packageFilesUrl = `https://data.jsdelivr.com/v1/package/npm/${name}@${version}`;
+				const packageFilesResponse = await fetch(packageFilesUrl);
+				const { default: defaultFile } = await packageFilesResponse.json();
+
+				const cdnUrl = defaultFile ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
+
+				const menu = (
+					<details class="dropdown details-reset details-overlay">
+						<summary class="btn btn-sm ml-2 jsd-btn-orange">
+							jsDelivr CDN
+							&nbsp;
+							<span class="dropdown-caret"></span>
+						</summary>
+
+						<div class="position-relative">
+							<div class="get-repo-modal dropdown-menu dropdown-menu-sw pb-0">
+								<div class="get-repo-modal-options">
+									<div class="clone-options">
+										<h4 class="mb-1">
+											Serve with jsDelivr CDN
+										</h4>
+										{cdnUrl
+											? (
+												<div>
+													<p class="mb-2 get-repo-decription-text">
+														Use this URL in your web page.
+													</p>
+													<div class="input-group">
+														<input
+															type="text"
+															class="form-control input-monospace input-sm"
+															value={cdnUrl}
+															aria-label={`Load this repository at ${cdnUrl}`}
+															readonly
+														/>
+														<div class="input-group-button">
+															<clipboard-copy
+																class="btn btn-sm"
+																value={cdnUrl}
+																tabindex="0"
+																role="button"
+																aria-label="Copy to clipboard"
+															>
+																{clippy()}
+															</clipboard-copy>
+														</div>
+													</div>
+												</div>
+											)
+											: (
+												<div class="flash flash-warn my-2 jsd-flash">
+													Sadly, this package doesn't have a default file set.
+												</div>
+											)
+										}
+									</div>
+								</div>
+							</div>
+						</div>
+					</details>
+				);
+
+				const fileNavigation = document.querySelector('.file-navigation');
+
+				if (fileNavigation) {
+					fileNavigation.append(menu);
+				}
+			} catch (error) {
+				console.error(error);
+			}
+		}
+	}
+}
+
+init();
+
+document.addEventListener('pjax:end', init);

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -93,13 +93,18 @@ async function init () {
 										>
 											Open in jsDelivr
 										</a>
-										<a
-											class="btn btn-outline get-repo-btn"
-											href={`https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`}
-											rel="nofollow"
-										>
-											Download ZIP
-										</a>
+										{cdnUrl
+											? (
+												<a
+													class="btn btn-outline get-repo-btn"
+													href={`https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`}
+													rel="nofollow"
+												>
+													Download ZIP
+												</a>
+											)
+											: null
+										}
 									</div>
 								</div>
 							</div>

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -13,6 +13,10 @@ async function init () {
 	if (isGitHub()) {
 		if (isRepoRoot()) {
 			try {
+				if (document.querySelector('.jsd-get-repo-select-menu')) {
+					return;
+				}
+
 				const { ownerName, repoName, treeName } = getRepoDetails();
 
 				const rawPackageUrl = `https://raw.githubusercontent.com/${ownerName}/${repoName}/${treeName}/package.json`;
@@ -30,7 +34,7 @@ async function init () {
 				const cdnUrl = defaultFile ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
 
 				const menu = (
-					<details class="dropdown details-reset details-overlay">
+					<details class="jsd-get-repo-select-menu dropdown details-reset details-overlay">
 						<summary class="btn btn-sm ml-2 jsd-btn-orange">
 							jsDelivr CDN
 							&nbsp;

--- a/src/libs/icons.js
+++ b/src/libs/icons.js
@@ -1,0 +1,7 @@
+import React from 'dom-chef';
+
+export const clippy = () => (
+	<svg class="octicon octicon-clippy" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true">
+		<path fill-rule="evenodd" d="M2 13h4v1H2v-1zm5-6H2v1h5V7zm2 3V8l-3 3 3 3v-2h5v-2H9zM4.5 9H2v1h2.5V9zM2 12h2.5v-1H2v1zm9 1h1v2c-.02.28-.11.52-.3.7-.19.18-.42.28-.7.3H1c-.55 0-1-.45-1-1V4c0-.55.45-1 1-1h3c0-1.11.89-2 2-2 1.11 0 2 .89 2 2h3c.55 0 1 .45 1 1v5h-1V6H1v9h10v-2zM2 5h8c0-.55-.45-1-1-1H8c-.55 0-1-.45-1-1s-.45-1-1-1-1 .45-1 1-.45 1-1 1H3c-.55 0-1 .45-1 1z"></path>
+	</svg>
+);

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -1,3 +1,6 @@
+// Functions referenced and modified from Sindre Sorhus's `refined-github` repository
+// Source: https://github.com/sindresorhus/refined-github/blob/master/source/libs/page-detect.ts
+
 import { getCleanPathname, getRepoPath } from './utils';
 
 export const isGitHub = () => location.hostname === 'github.com';

--- a/src/libs/page-detect.js
+++ b/src/libs/page-detect.js
@@ -1,0 +1,17 @@
+import { getCleanPathname, getRepoPath } from './utils';
+
+export const isGitHub = () => location.hostname === 'github.com';
+
+// 'user/repo'            -> true
+// 'user/repo/tree/1.0.0' -> false
+export const isRepoRootMaster = () => /^[^/]+\/[^/]+$/.test(getCleanPathname());
+
+// '/user/repo/tree/1.0.0'     -> true
+// '/user/repo/tree/1.0.0/lib' -> false
+export const isRepoRootTree = () => /^(tree[/][^/]+)?$/.test(getRepoPath());
+
+const hasCloneButton = () => Boolean(document.querySelector('.get-repo-select-menu'));
+
+export const isRepoRoot = () => {
+	return (isRepoRootMaster() || isRepoRootTree()) && hasCloneButton();
+};

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -1,0 +1,19 @@
+// Remove leading and trailing slashes
+// '/user/repo'  -> 'user/repo'
+// '/user/repo/' -> 'user/repo'
+export const getCleanPathname = () => location.pathname.replace(/^[/]/g, '').replace(/[/]$/g, '');
+
+// Parses a repo's subpage
+// '/user/repo/tree/1.0.0' -> 'tree/1.0.0'
+// '/user/repo'            -> ''
+export const getRepoPath = () => getCleanPathname().split('/').slice(2).join('/');
+
+export const getRepoDetails = () => {
+	const [ ownerName, repoName, , treeName = 'master' ] = getCleanPathname().split('/');
+
+	return {
+		ownerName,
+		repoName,
+		treeName,
+	};
+};

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -20,3 +20,8 @@ export const getRepoDetails = () => {
 		treeName,
 	};
 };
+
+// Check for `.js` extension
+// '/dist/index.min.js' -> true
+// '/dist/index'        -> false
+export const hasJSExtension = filename => /(\.js)$/.test(filename);

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -1,3 +1,6 @@
+// Functions referenced and modified from Sindre Sorhus's `refined-github` repository
+// Source: https://github.com/sindresorhus/refined-github/blob/master/source/libs/utils.ts
+
 // Remove leading and trailing slashes
 // '/user/repo'  -> 'user/repo'
 // '/user/repo/' -> 'user/repo'

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -25,3 +25,21 @@ export const getRepoDetails = () => {
 // '/dist/index.min.js' -> true
 // '/dist/index'        -> false
 export const hasJSExtension = filename => /(\.js)$/.test(filename);
+
+// Memoize function to store results of API calls
+// and return cached result for same inputs
+export const memo = (fn) => {
+	const cacheStore = new Map();
+
+	return async (...args) => {
+		const key = args.join('|');
+
+		if (cacheStore.has(key)) {
+			return cacheStore.get(key);
+		}
+
+		const result = await fn.call(null, ...args);
+		cacheStore.set(key, result);
+		return result;
+	};
+};

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,1 @@
+global.location = new URL('https://github.com');

--- a/test/page-detect.js
+++ b/test/page-detect.js
@@ -1,0 +1,66 @@
+import chai from 'chai';
+import { isGitHub, isRepoRootMaster, isRepoRootTree } from '../src/libs/page-detect';
+
+const assert = chai.assert;
+
+describe('page-detect', () => {
+	describe('isGitHub', () => {
+		it('should detect if current page is GitHub', () => {
+			location.href = 'https://github.com/jquery/jquery';
+			assert.isTrue(isGitHub());
+
+			location.href = 'https://www.npmjs.com/package/jquery';
+			assert.isFalse(isGitHub());
+		});
+	});
+
+	describe('isRepoRootMaster', () => {
+		it('should detect if current page is a root of a GitHub repository on master branch', () => {
+			const masterRootRepos = [
+				'https://github.com/jquery/jquery',
+				'https://github.com/kenwheeler/slick',
+			];
+
+			const insideMasterRepos = [
+				'https://github.com/jquery/jquery/tree/master/src',
+				'https://github.com/kenwheeler/slick/tree/master/slick',
+			];
+
+			for (const url of masterRootRepos) {
+				location.href = url;
+				assert.isTrue(isRepoRootMaster());
+			}
+
+			for (const url of insideMasterRepos) {
+				location.href = url;
+				assert.isFalse(isRepoRootMaster());
+			}
+		});
+	});
+
+	describe('isRepoRootTree', () => {
+		it('should detect if current page is a root of a GitHub repository on tagged release or branch other than master', () => {
+			const treeRootRepos = [
+				'https://github.com/jquery/jquery/tree/master',
+				'https://github.com/jquery/jquery/tree/3.0.0',
+				'https://github.com/kenwheeler/slick/tree/1.5.6',
+			];
+
+			const insideTreeRepos = [
+				'https://github.com/jquery/jquery/tree/master/src',
+				'https://github.com/jquery/jquery/tree/3.0.0/src',
+				'https://github.com/kenwheeler/slick/tree/1.5.6/slick',
+			];
+
+			for (const url of treeRootRepos) {
+				location.href = url;
+				assert.isTrue(isRepoRootTree());
+			}
+
+			for (const url of insideTreeRepos) {
+				location.href = url;
+				assert.isFalse(isRepoRootTree());
+			}
+		});
+	});
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,8 +1,9 @@
 import chai from 'chai';
 
-import { getCleanPathname, getRepoPath, getRepoDetails } from '../src/libs/utils';
+import { getCleanPathname, getRepoPath, getRepoDetails, hasJSExtension } from '../src/libs/utils';
 
 const expect = chai.expect;
+const assert = chai.assert;
 
 describe('utils', () => {
 	describe('getCleanPathname', () => {
@@ -97,6 +98,28 @@ describe('utils', () => {
 				location.href = url;
 				const details = getRepoDetails();
 				expect(details).to.deep.equal(result);
+			}
+		});
+	});
+
+	describe('hasJSExtension', () => {
+		it('should check if a file has `.js` extension in its name', () => {
+			const withJSExtension = [
+				'/dist/jquery.min.js',
+				'/slick/slick.min.js',
+			];
+
+			const withoutJSExtension = [
+				'/dist/js/bootstrap',
+				'/js/swiper',
+			];
+
+			for (const filename of withJSExtension) {
+				assert.isTrue(hasJSExtension(filename));
+			}
+
+			for (const filename of withoutJSExtension) {
+				assert.isFalse(hasJSExtension(filename));
 			}
 		});
 	});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,103 @@
+import chai from 'chai';
+
+import { getCleanPathname, getRepoPath, getRepoDetails } from '../src/libs/utils';
+
+const expect = chai.expect;
+
+describe('utils', () => {
+	describe('getCleanPathname', () => {
+		it('should remove leading and trailing slashed from pathname', () => {
+			const shouldMatch = [
+				{
+					url: 'https://github.com/jquery/jquery',
+					result: 'jquery/jquery',
+				},
+				{
+					url: 'https://github.com/jquery/jquery/',
+					result: 'jquery/jquery',
+				},
+			];
+
+			const shouldNotMatch = [
+				{
+					url: 'https://github.com/jquery/jquery',
+					result: '/jquery/jquery',
+				},
+				{
+					url: 'https://github.com/jquery/jquery/',
+					result: '/jquery/jquery/',
+				},
+			];
+
+			for (const { url, result } of shouldMatch) {
+				location.href = url;
+				const pathname = getCleanPathname();
+				expect(pathname).to.equal(result);
+			}
+
+			for (const { url, result } of shouldNotMatch) {
+				location.href = url;
+				const pathname = getCleanPathname();
+				expect(pathname).to.not.equal(result);
+			}
+		});
+	});
+
+	describe('getRepoPath', () => {
+		it('should get a repository path from current URL', () => {
+			const shouldMatch = [
+				{
+					url: 'https://github.com/jquery/jquery',
+					result: '',
+				},
+				{
+					url: 'https://github.com/jquery/jquery/tree/3.3.0',
+					result: 'tree/3.3.0',
+				},
+			];
+
+			for (const { url, result } of shouldMatch) {
+				location.href = url;
+				const path = getRepoPath();
+				expect(path).to.equal(result);
+			}
+		});
+	});
+
+	describe('getRepoDetails', () => {
+		it('should get repository details from current URL', () => {
+			const shouldMatch = [
+				{
+					url: 'https://github.com/jquery/jquery',
+					result: {
+						ownerName: 'jquery',
+						repoName: 'jquery',
+						treeName: 'master',
+					},
+				},
+				{
+					url: 'https://github.com/kenwheeler/slick',
+					result: {
+						ownerName: 'kenwheeler',
+						repoName: 'slick',
+						treeName: 'master',
+					},
+				},
+				{
+					url: 'https://github.com/jquery/jquery/tree/3.0.0',
+					result: {
+						ownerName: 'jquery',
+						repoName: 'jquery',
+						treeName: '3.0.0',
+					},
+				},
+			];
+
+			for (const { url, result } of shouldMatch) {
+				location.href = url;
+				const details = getRepoDetails();
+				expect(details).to.deep.equal(result);
+			}
+		});
+	});
+});


### PR DESCRIPTION
**Add a jsDelivr CDN button for GitHub**
Show a download button if we are able to retrieve repository's name and version from it's package file

**Provide jsDelivr CDN link for a repository**
If a default file name is set for a repository, provide user with:
- A jsDelivr CDN link
- A download ZIP files button
- And a link which takes user to jsDelivr page of a repository

<img width="640" alt="repo-with-default-file" src="https://user-images.githubusercontent.com/12200583/66033964-f6486100-e525-11e9-979a-2f3af7a7593f.png">

---

**Show warning message if link is not available**
If CDN link is not available, add a jsDelivr page link where user can select the files.

<img width="640" alt="repo-without-default-file" src="https://user-images.githubusercontent.com/12200583/66034487-f301a500-e526-11e9-80d4-a6971071df8c.png">

---

Add **mocha** and **chai** for testing the utility functions.

