### PR TITLE
Add jsDelivr CDN link for npm

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,5 +29,8 @@
 				]
 			}
 		}
-	]
+	],
+	"globals": {
+		"chrome": false
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2041,6 +2041,11 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "copy-text-to-clipboard": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-2.1.1.tgz",
+      "integrity": "sha512-oSuMj4ArDGSLcLPsDhzWOhalzOVV0ErCHNfZNNr+spC+iWJ6PVSLzPPrJw/rcdFZyOhugn8iw6O0nrpY/ZrEMg=="
+    },
     "copy-webpack-plugin": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-5.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
 		"webpack-cli": "^3.3.9"
 	},
 	"dependencies": {
+		"copy-text-to-clipboard": "^2.1.1",
 		"dom-chef": "^3.6.2",
 		"dom-loaded": "^2.0.0"
 	}

--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,23 @@
+import { isNpm } from './libs/npm-page-detect';
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+	const { status, url } = tab;
+
+	if (!url) {
+		return;
+	}
+
+	const location = new URL(url);
+
+	if (!isNpm(location)) {
+		return;
+	}
+
+	if (status === 'complete') {
+		const message = {
+			type: 'TAB_UPDATE',
+		};
+
+		chrome.tabs.sendMessage(tabId, message);
+	}
+});

--- a/src/content-npm.js
+++ b/src/content-npm.js
@@ -1,0 +1,1 @@
+import './features/npm-cdn-link';

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import onDomReady from 'dom-loaded';
 
 import { isGitHub, isRepoRoot } from '../libs/page-detect';
-import { getRepoDetails, hasJSExtension, memo } from '../libs/utils';
+import { getRepoDetails, hasJSExtension, memo, getPackageVersion, getDefaultFile } from '../libs/utils';
 import { clippy } from '../libs/icons';
 
 import './github-download-button.css';
@@ -14,25 +14,6 @@ import './github-download-button.css';
 		const { name } = await rawPackageResponse.json();
 
 		return name;
-	}
-
-	// eslint-disable-next-line no-unused-vars
-	async function getPackageVersion (name, treeName) {
-		const packageVersionsUrl = `https://data.jsdelivr.com/v1/package/npm/${name}`;
-		const packageVersionsResponse = await fetch(packageVersionsUrl);
-		const { tags, versions } = await packageVersionsResponse.json();
-
-		const version = tags.latest ? tags.latest : versions[0];
-
-		return version;
-	}
-
-	async function getDefaultFile (name, version) {
-		const packageFilesUrl = `https://data.jsdelivr.com/v1/package/npm/${name}@${version}`;
-		const packageFilesResponse = await fetch(packageFilesUrl);
-		const { default: defaultFile } = await packageFilesResponse.json();
-
-		return defaultFile;
 	}
 
 	async function init () {

--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -2,7 +2,7 @@ import React from 'dom-chef';
 import onDomReady from 'dom-loaded';
 
 import { isGitHub, isRepoRoot } from '../libs/page-detect';
-import { getRepoDetails, hasJSExtension, memo, getPackageVersion, getDefaultFile } from '../libs/utils';
+import { getRepoDetails, memo, getPackageVersion, getDefaultFile } from '../libs/utils';
 import { clippy } from '../libs/icons';
 
 import './github-download-button.css';
@@ -37,9 +37,7 @@ import './github-download-button.css';
 
 				const defaultFile = await getDefaultFileMemo(name, version);
 
-				// Validate file name, since `bootstrap`
-				// has default file name without `.js` extension
-				const cdnUrl = defaultFile && hasJSExtension(defaultFile) ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
+				const cdnUrl = defaultFile ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
 
 				const menu = (
 					<details class="jsd-get-repo-select-menu dropdown details-reset details-overlay">

--- a/src/features/npm-cdn-link.css
+++ b/src/features/npm-cdn-link.css
@@ -1,0 +1,112 @@
+/* Copy npm css since npm minifies their class names */
+
+.jsd-npm-title {
+	font-size: 1rem;
+	color: rgba(0, 0, 0, .5);
+	padding-top: .5rem;
+	margin-top: .5rem;
+	margin-bottom: 0;
+}
+
+.jsd-npm-link-container {
+	border: 1px #e8e8e8 solid;
+	border-left: 6px #e1e1e1 solid;
+	padding: 5px 1rem;
+	max-width: 95vw;
+	margin-top: .875rem;
+	margin-bottom: 1rem;
+	display: flex;
+	flex-direction: row;
+	border-radius: .25rem;
+	box-sizing: border-box;
+}
+
+.jsd-npm-link-input {
+	width: 100%;
+	border: 0;
+	font-family: "Fira Mono", "Andale Mono", Consolas, monospace;
+	letter-spacing: 0;
+	-webkit-font-feature-settings: none;
+	font-feature-settings: none;
+	-webkit-font-variant-ligatures: none;
+	font-variant-ligatures: none;
+	line-height: 22px;
+	font-size: .875rem;
+	color: rgba(0, 0, 0, .8);
+}
+
+.jsd-npm-link-input:hover {
+	background-color: #accef7;
+}
+
+.jsd-npm-link-input:focus {
+	border: none;
+	outline: none;
+}
+
+.jsd-npm-no-file-container {
+	margin-top: .5rem;
+}
+
+.jsd-npm-no-file-message {
+	color: #333;
+	letter-spacing: .25px;
+	line-height: 22px;
+	margin: 0;
+}
+
+.jsd-npm-button {
+	background-image: linear-gradient(-180deg, rgba(255, 255, 255, .09) 0%, rgba(247, 102, 65, .1) 97%);
+	border: 1px solid rgba(253, 156, 128, .6);
+	color: #f96940;
+	background-color: #fff;
+	letter-spacing: .25px;
+	font-size: 1rem;
+	text-align: center;
+	text-decoration: none;
+	margin: .5rem;
+	margin-left: 0;
+	padding: .5rem 1rem;
+	font-weight: 500;
+	display: inline-block;
+	border-radius: .25rem;
+	box-sizing: border-box;
+}
+
+.jsd-npm-button:hover {
+	background-image: linear-gradient(-180deg, rgba(255, 255, 255, .18) 0%, rgba(247, 102, 65, .2) 97%);
+	border: 1px solid rgba(253, 156, 128, .5);
+	color: #ec4b1e;
+}
+
+.jsd-npm-toast-container {
+	width: 100%;
+	padding: 1rem 4rem;
+	font-family: "Source Sans Pro", "Lucida Grande", sans-serif;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	position: fixed;
+	top: 0;
+	left: 0;
+	z-index: 999;
+	background-color: #dbffdb;
+	color: #3d8f3d;
+	border-bottom: 1px solid rgba(0, 0, 0, .1);
+	transition: opacity 1s linear;
+	box-sizing: border-box;
+	user-select: none;
+	cursor: pointer;
+}
+
+.jsd-npm-toast-message {
+	margin: 0;
+}
+
+.jsd-npm-toast-close-btn {
+	font-size: 1.5rem;
+	font-weight: 600;
+	line-height: 1rem;
+	height: 1rem;
+	margin: 0;
+}

--- a/src/features/npm-cdn-link.js
+++ b/src/features/npm-cdn-link.js
@@ -3,7 +3,7 @@ import copy from 'copy-text-to-clipboard';
 
 import { isPackageRoot } from '../libs/npm-page-detect';
 import { getPackageDetails } from '../libs/npm-utils';
-import { memo, getPackageVersion, getDefaultFile, hasJSExtension } from '../libs/utils';
+import { memo, getPackageVersion, getDefaultFile } from '../libs/utils';
 
 import './npm-cdn-link.css';
 
@@ -136,9 +136,7 @@ chrome.runtime.onMessage.addListener(async (request) => {
 
 		const defaultFile = await getDefaultFileMemo(name, version);
 
-		// Validate file name, since `bootstrap`
-		// has default file name without `.js` extension
-		const cdnUrl = defaultFile && hasJSExtension(defaultFile) ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
+		const cdnUrl = defaultFile ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
 
 		setCDNLink({
 			name,

--- a/src/features/npm-cdn-link.js
+++ b/src/features/npm-cdn-link.js
@@ -1,0 +1,148 @@
+import React from 'dom-chef';
+import copy from 'copy-text-to-clipboard';
+
+import { isPackageRoot } from '../libs/npm-page-detect';
+import { getPackageDetails } from '../libs/npm-utils';
+import { memo, getPackageVersion, getDefaultFile, hasJSExtension } from '../libs/utils';
+
+import './npm-cdn-link.css';
+
+const getPackageVersionMemo = memo(getPackageVersion);
+const getDefaultFileMemo = memo(getDefaultFile);
+
+// Set `currentPageUrl` as empty string instead of `location.href`.
+// This helps in determining whether to add a cdn link or not,
+// for scenarios where a user directly lands on a package page or refreshes it
+let currentPageUrl = '';
+
+function hasRouteChanged () {
+	const nextPageUrl = window.location.href;
+
+	if (currentPageUrl === '' || currentPageUrl !== nextPageUrl) {
+		currentPageUrl = nextPageUrl;
+		return true;
+	}
+
+	return false;
+}
+
+function removeCDNLink () {
+	const existingLink = document.querySelector('#jsd-npm-container');
+
+	if (existingLink) {
+		existingLink.remove();
+	}
+}
+
+function setCDNLink ({ name, cdnUrl }) {
+	const headingElements = [ ...document.querySelectorAll('h3') ];
+	const installHeadingElement = headingElements.find(element => element.innerText.toLowerCase() === 'install');
+
+	if (!installHeadingElement) {
+		return;
+	}
+
+	function handleLinkClick () {
+		copy(cdnUrl);
+		setToast({
+			message: 'Copied to clipboard!',
+		});
+	}
+
+	const link = (
+		<div id="jsd-npm-container">
+			<h3 class="jsd-npm-title">jsdelivr cdn</h3>
+			{cdnUrl
+				? (
+					<div class="jsd-npm-link-container">
+						<input
+							class="jsd-npm-link-input"
+							value={cdnUrl}
+							onClick={handleLinkClick}
+							readonly
+						/>
+					</div>
+				)
+				: (
+					<div class="jsd-npm-no-file-container">
+						<p class="jsd-npm-no-file-message">
+							Sadly, this package doesn't have a default file set.
+						</p>
+						<a
+							class="jsd-npm-button"
+							href={`https://www.jsdelivr.com/package/npm/${name}`}
+							target="_blank"
+							rel="nofollow"
+						>
+							Open in jsDelivr
+						</a>
+					</div>
+				)
+			}
+		</div>
+	);
+
+	const installCommandElement = installHeadingElement.nextElementSibling;
+
+	if (installCommandElement) {
+		installCommandElement.insertAdjacentElement('afterend', link);
+		currentPageUrl = window.location.href;
+	}
+}
+
+function removeToast () {
+	const toastElement = document.querySelector('#jsd-npm-toast');
+
+	if (toastElement) {
+		toastElement.remove();
+	}
+}
+
+function setToast ({ message = '' }) {
+	const toast = (
+		<div
+			id="jsd-npm-toast"
+			class="jsd-npm-toast-container"
+			onClick={removeToast}
+		>
+			<p class="jsd-npm-toast-message">{message}</p>
+			<p class="jsd-npm-toast-close-btn">×</p>
+		</div>
+	);
+
+	document.querySelector('body').append(toast);
+	setTimeout(() => {
+		removeToast();
+	}, 2000);
+}
+
+chrome.runtime.onMessage.addListener(async (request) => {
+	const { type } = request;
+
+	if (type === 'TAB_UPDATE' && hasRouteChanged() && isPackageRoot()) {
+		removeCDNLink();
+
+		const { name, version: versionName } = getPackageDetails();
+
+		if (!name) {
+			return;
+		}
+
+		const version = versionName ? versionName : await getPackageVersionMemo(name, 'master');
+
+		if (!version) {
+			return;
+		}
+
+		const defaultFile = await getDefaultFileMemo(name, version);
+
+		// Validate file name, since `bootstrap`
+		// has default file name without `.js` extension
+		const cdnUrl = defaultFile && hasJSExtension(defaultFile) ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
+
+		setCDNLink({
+			name,
+			cdnUrl,
+		});
+	}
+});

--- a/src/libs/npm-page-detect.js
+++ b/src/libs/npm-page-detect.js
@@ -1,0 +1,24 @@
+import { getCleanPathname } from './utils';
+import { NPM_REGEX } from './npm-utils';
+
+export const isNpm = (locationObj = location) => locationObj.hostname === 'www.npmjs.com';
+
+// 'package/name'        -> true
+// 'package/@scope/name' -> true
+export const isPackageRootMaster = () => {
+	const pathname = getCleanPathname();
+
+	return NPM_REGEX.scopedPackage.test(pathname) || NPM_REGEX.package.test(pathname);
+};
+
+// 'package/name/v/1.0.0'        -> true
+// 'package/@scope/name/v/1.0.0' -> true
+export const isPackageRootVersion = () => {
+	const pathname = getCleanPathname();
+
+	return NPM_REGEX.scopedPackageWithVersion.test(pathname) || NPM_REGEX.packageWithVersion.test(pathname);
+};
+
+export const isPackageRoot = () => {
+	return isPackageRootMaster() || isPackageRootVersion();
+};

--- a/src/libs/npm-utils.js
+++ b/src/libs/npm-utils.js
@@ -1,0 +1,50 @@
+import { getCleanPathname } from './utils';
+
+export const NPM_REGEX = {
+	// 'package/name'
+	package: /^(?:package[/])(?<name>[^/]+)$/,
+	// 'package/name/v/1.0.0'
+	packageWithVersion: /^(?:package[/])(?<name>[^/]+)(?:[/]v[/])(?<version>[^/]+)$/,
+	// 'package/@scope/name'
+	scopedPackage: /^(?:package[/])(?<name>@[^/]+[/][^/]+)$/,
+	// 'package/@scope/name/v/1.0.0'
+	scopedPackageWithVersion: /^(?:package[/])(?<name>@[^/]+[/][^/]+)(?:[/]v[/])(?<version>[^/]+)$/,
+};
+
+export const getPackageDetails = () => {
+	const pathname = getCleanPathname();
+
+	const scopedPackageWithVersionMatches = pathname.match(NPM_REGEX.scopedPackageWithVersion) || [];
+
+	if (scopedPackageWithVersionMatches.groups) {
+		return {
+			...scopedPackageWithVersionMatches.groups,
+		};
+	}
+
+	const scopedPackageMatches = pathname.match(NPM_REGEX.scopedPackage) || [];
+
+	if (scopedPackageMatches.groups) {
+		return {
+			...scopedPackageMatches.groups,
+		};
+	}
+
+	const packageWithVersionMatches = pathname.match(NPM_REGEX.packageWithVersion) || [];
+
+	if (packageWithVersionMatches.groups) {
+		return {
+			...packageWithVersionMatches.groups,
+		};
+	}
+
+	const packageMatches = pathname.match(NPM_REGEX.package) || [];
+
+	if (packageMatches.groups) {
+		return {
+			...packageMatches.groups,
+		};
+	}
+
+	return {};
+};

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -26,6 +26,25 @@ export const getRepoDetails = () => {
 // '/dist/index'        -> false
 export const hasJSExtension = filename => /(\.js)$/.test(filename);
 
+// eslint-disable-next-line no-unused-vars
+export async function getPackageVersion (name, treeName) {
+	const packageVersionsUrl = `https://data.jsdelivr.com/v1/package/npm/${name}`;
+	const packageVersionsResponse = await fetch(packageVersionsUrl);
+	const { tags, versions } = await packageVersionsResponse.json();
+
+	const version = tags.latest ? tags.latest : versions[0];
+
+	return version;
+}
+
+export async function getDefaultFile (name, version) {
+	const packageFilesUrl = `https://data.jsdelivr.com/v1/package/npm/${name}@${version}`;
+	const packageFilesResponse = await fetch(packageFilesUrl);
+	const { default: defaultFile } = await packageFilesResponse.json();
+
+	return defaultFile;
+}
+
 // Memoize function to store results of API calls
 // and return cached result for same inputs
 export const memo = (fn) => {

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -21,11 +21,6 @@ export const getRepoDetails = () => {
 	};
 };
 
-// Check for `.js` extension
-// '/dist/index.min.js' -> true
-// '/dist/index'        -> false
-export const hasJSExtension = filename => /(\.js)$/.test(filename);
-
 // eslint-disable-next-line no-unused-vars
 export async function getPackageVersion (name, treeName) {
 	const packageVersionsUrl = `https://data.jsdelivr.com/v1/package/npm/${name}`;
@@ -38,11 +33,20 @@ export async function getPackageVersion (name, treeName) {
 }
 
 export async function getDefaultFile (name, version) {
-	const packageFilesUrl = `https://data.jsdelivr.com/v1/package/npm/${name}@${version}`;
+	const packageFilesUrl = `https://data.jsdelivr.com/v1/package/npm/${name}@${version}/flat`;
 	const packageFilesResponse = await fetch(packageFilesUrl);
-	const { default: defaultFile } = await packageFilesResponse.json();
+	const { default: defaultFile, files } = await packageFilesResponse.json();
 
-	return defaultFile;
+	const nonMinifiedFile = defaultFile.replace(/\.min\.(js|css)$/i, '.$1');
+	const hasDefaultFile = files.some((file) => {
+		return file.name === defaultFile || file.name === nonMinifiedFile;
+	});
+
+	if (hasDefaultFile) {
+		return defaultFile;
+	}
+
+	return '';
 }
 
 // Memoize function to store results of API calls

--- a/src/libs/utils.js
+++ b/src/libs/utils.js
@@ -37,6 +37,10 @@ export async function getDefaultFile (name, version) {
 	const packageFilesResponse = await fetch(packageFilesUrl);
 	const { default: defaultFile, files } = await packageFilesResponse.json();
 
+	if (!defaultFile) {
+		return '';
+	}
+
 	const nonMinifiedFile = defaultFile.replace(/\.min\.(js|css)$/i, '.$1');
 	const hasDefaultFile = files.some((file) => {
 		return file.name === defaultFile || file.name === nonMinifiedFile;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -10,6 +10,7 @@
 		"default_icon": "icon.png"
 	},
 	"permissions": [
+		"activeTab",
 		"https://github.com/*",
 		"https://www.npmjs.com/*"
 	],
@@ -17,8 +18,7 @@
 		{
 			"run_at": "document_start",
 			"matches": [
-				"https://github.com/*",
-				"https://www.npmjs.com/*"
+				"https://github.com/*"
 			],
 			"css": [
 				"content.css"
@@ -26,6 +26,24 @@
 			"js": [
 				"content.js"
 			]
+		},
+		{
+			"run_at": "document_start",
+			"matches": [
+				"https://www.npmjs.com/*"
+			],
+			"css": [
+				"content-npm.css"
+			],
+			"js": [
+				"content-npm.js"
+			]
 		}
-	]
+	],
+	"background": {
+		"scripts": [
+			"background.js"
+		],
+		"persistent": false
+	}
 }

--- a/test/npm-page-detect.js
+++ b/test/npm-page-detect.js
@@ -1,0 +1,66 @@
+import chai from 'chai';
+import { isNpm, isPackageRootMaster, isPackageRootVersion } from '../src/libs/npm-page-detect';
+
+const assert = chai.assert;
+
+describe('npm-page-detect', () => {
+	describe('isNpm', () => {
+		it('should detect if current page is of npm website', () => {
+			location.href = 'https://www.npmjs.com/package/jquery';
+			assert.isTrue(isNpm());
+			assert.isTrue(isNpm(new URL(location)));
+
+			location.href = 'https://github.com/jquery/jquery';
+			assert.isFalse(isNpm());
+			assert.isFalse(isNpm(new URL(location)));
+		});
+	});
+
+	describe('isPackageRootMaster', () => {
+		it('should detect if current page is a root of a npm package', () => {
+			const packagesWithoutVersion = [
+				'https://www.npmjs.com/package/jquery',
+				'https://www.npmjs.com/package/@sindresorhus/is',
+			];
+
+			const packagesWithVersion = [
+				'https://www.npmjs.com/package/jquery/v/3.4.1',
+				'https://www.npmjs.com/package/@sindresorhus/is/v/1.2.0',
+			];
+
+			for (const url of packagesWithoutVersion) {
+				location.href = url;
+				assert.isTrue(isPackageRootMaster());
+			}
+
+			for (const url of packagesWithVersion) {
+				location.href = url;
+				assert.isFalse(isPackageRootMaster());
+			}
+		});
+	});
+
+	describe('isPackageRootVersion', () => {
+		it('should detect if current page is a root of a npm package with a specific version', () => {
+			const packagesWithVersion = [
+				'https://www.npmjs.com/package/jquery/v/3.4.1',
+				'https://www.npmjs.com/package/@sindresorhus/is/v/1.2.0',
+			];
+
+			const packagesWithoutVersion = [
+				'https://www.npmjs.com/package/jquery',
+				'https://www.npmjs.com/package/@sindresorhus/is',
+			];
+
+			for (const url of packagesWithVersion) {
+				location.href = url;
+				assert.isTrue(isPackageRootVersion());
+			}
+
+			for (const url of packagesWithoutVersion) {
+				location.href = url;
+				assert.isFalse(isPackageRootVersion());
+			}
+		});
+	});
+});

--- a/test/npm-utils.js
+++ b/test/npm-utils.js
@@ -1,0 +1,46 @@
+import chai from 'chai';
+
+import { getPackageDetails } from '../src/libs/npm-utils';
+
+const expect = chai.expect;
+
+describe('npm-utils', () => {
+	describe('getPackageDetails', () => {
+		it('should get package details from current URL', () => {
+			const shouldMatch = [
+				{
+					url: 'https://www.npmjs.com/package/jquery',
+					result: {
+						name: 'jquery',
+					},
+				},
+				{
+					url: 'https://www.npmjs.com/package/@sindresorhus/is',
+					result: {
+						name: '@sindresorhus/is',
+					},
+				},
+				{
+					url: 'https://www.npmjs.com/package/jquery/v/3.4.1',
+					result: {
+						name: 'jquery',
+						version: '3.4.1',
+					},
+				},
+				{
+					url: 'https://www.npmjs.com/package/@sindresorhus/is/v/1.2.0',
+					result: {
+						name: '@sindresorhus/is',
+						version: '1.2.0',
+					},
+				},
+			];
+
+			for (const { url, result } of shouldMatch) {
+				location.href = url;
+				const details = getPackageDetails();
+				expect(details).to.deep.equal(result);
+			}
+		});
+	});
+});

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,9 +1,8 @@
 import chai from 'chai';
 
-import { getCleanPathname, getRepoPath, getRepoDetails, hasJSExtension } from '../src/libs/utils';
+import { getCleanPathname, getRepoPath, getRepoDetails } from '../src/libs/utils';
 
 const expect = chai.expect;
-const assert = chai.assert;
 
 describe('utils', () => {
 	describe('getCleanPathname', () => {
@@ -98,28 +97,6 @@ describe('utils', () => {
 				location.href = url;
 				const details = getRepoDetails();
 				expect(details).to.deep.equal(result);
-			}
-		});
-	});
-
-	describe('hasJSExtension', () => {
-		it('should check if a file has `.js` extension in its name', () => {
-			const withJSExtension = [
-				'/dist/jquery.min.js',
-				'/slick/slick.min.js',
-			];
-
-			const withoutJSExtension = [
-				'/dist/js/bootstrap',
-				'/js/swiper',
-			];
-
-			for (const filename of withJSExtension) {
-				assert.isTrue(hasJSExtension(filename));
-			}
-
-			for (const filename of withoutJSExtension) {
-				assert.isFalse(hasJSExtension(filename));
 			}
 		});
 	});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,9 @@ module.exports = {
 		builtAt: true,
 	},
 	entry: {
-		content: './src/content'
+		content: './src/content',
+		'content-npm': './src/content-npm',
+		background: './src/background'
 	},
 	output: {
 		path: path.join(__dirname, 'build'),


### PR DESCRIPTION
**Add a jsDelivr CDN link for npm**
Show a CDN link if package's default file is set.

**Provide jsDelivr CDN link for a package**
If a default file name is set for a package, provide user with a CDN link.

<img width="640" alt="package-with-default-file" src="https://user-images.githubusercontent.com/12200583/66852848-8614f300-ef9b-11e9-948e-2d3927485cac.png">

---

**Show warning message if link is not available**
If CDN link is not available, add a jsDelivr page link where user can select the files.

<img width="640" alt="package-without-default-file" src="https://user-images.githubusercontent.com/12200583/66852860-8ad9a700-ef9b-11e9-9a3c-c13eb6a9fcd9.png">
