### PR TITLE
Refactor GitHub code

### DIFF
--- a/src/features/github-download-button.js
+++ b/src/features/github-download-button.js
@@ -1,145 +1,137 @@
 import React from 'dom-chef';
 import onDomReady from 'dom-loaded';
 
-import { isGitHub, isRepoRoot } from '../libs/github-page-detect';
+import { isRepoRoot } from '../libs/github-page-detect';
 import { memo, getPackageVersion, getDefaultFile } from '../libs/utils';
 import { getRepoDetails } from '../libs/github-utils';
 import { clippy } from '../libs/icons';
 
 import './github-download-button.css';
 
-(function () {
-	async function getPackageName (ownerName, repoName, treeName) {
-		const rawPackageUrl = `https://raw.githubusercontent.com/${ownerName}/${repoName}/${treeName}/package.json`;
-		const rawPackageResponse = await fetch(rawPackageUrl);
-		const { name } = await rawPackageResponse.json();
+async function getPackageName (ownerName, repoName, treeName) {
+	const rawPackageUrl = `https://raw.githubusercontent.com/${ownerName}/${repoName}/${treeName}/package.json`;
+	const rawPackageResponse = await fetch(rawPackageUrl);
+	const { name } = await rawPackageResponse.json();
 
-		return name;
-	}
+	return name;
+}
 
-	async function init () {
-		await onDomReady;
+async function init () {
+	await onDomReady;
 
-		if (isRepoRoot()) {
-			try {
-				if (document.querySelector('.jsd-get-repo-select-menu')) {
-					return;
-				}
+	if (isRepoRoot()) {
+		try {
+			if (document.querySelector('.jsd-get-repo-select-menu')) {
+				return;
+			}
 
-				const { ownerName, repoName, treeName } = getRepoDetails();
+			const { ownerName, repoName, treeName } = getRepoDetails();
 
-				const name = await getPackageNameMemo(ownerName, repoName, treeName);
+			const name = await getPackageNameMemo(ownerName, repoName, treeName);
 
-				if (!name) {
-					return;
-				}
+			if (!name) {
+				return;
+			}
 
-				const version = await getPackageVersionMemo(name, treeName);
+			const version = await getPackageVersionMemo(name, treeName);
 
-				const defaultFile = await getDefaultFileMemo(name, version);
+			const defaultFile = await getDefaultFileMemo(name, version);
 
-				const cdnUrl = defaultFile ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
+			const cdnUrl = defaultFile ? `https://cdn.jsdelivr.net/npm/${name}@${version}${defaultFile}` : '';
 
-				const menu = (
-					<details class="jsd-get-repo-select-menu dropdown details-reset details-overlay">
-						<summary class="btn btn-sm ml-2 jsd-btn-orange">
-							jsDelivr CDN
-							&nbsp;
-							<span class="dropdown-caret"></span>
-						</summary>
+			const menu = (
+				<details class="jsd-get-repo-select-menu dropdown details-reset details-overlay">
+					<summary class="btn btn-sm ml-2 jsd-btn-orange">
+						jsDelivr CDN
+						&nbsp;
+						<span class="dropdown-caret"></span>
+					</summary>
 
-						<div class="position-relative">
-							<div class="get-repo-modal dropdown-menu dropdown-menu-sw pb-0">
-								<div class="get-repo-modal-options">
-									<div class="clone-options">
-										<h4 class="mb-1">
-											Serve with jsDelivr CDN
-										</h4>
-										{cdnUrl
-											? (
-												<div>
-													<p class="mb-2 get-repo-decription-text">
-														Use this URL in your web page.
-													</p>
-													<div class="input-group">
-														<input
-															type="text"
-															class="form-control input-monospace input-sm"
+					<div class="position-relative">
+						<div class="get-repo-modal dropdown-menu dropdown-menu-sw pb-0">
+							<div class="get-repo-modal-options">
+								<div class="clone-options">
+									<h4 class="mb-1">
+										Serve with jsDelivr CDN
+									</h4>
+									{cdnUrl
+										? (
+											<div>
+												<p class="mb-2 get-repo-decription-text">
+													Use this URL in your web page.
+												</p>
+												<div class="input-group">
+													<input
+														type="text"
+														class="form-control input-monospace input-sm"
+														value={cdnUrl}
+														aria-label={`Load this repository at ${cdnUrl}`}
+														readonly
+													/>
+													<div class="input-group-button">
+														<clipboard-copy
+															class="btn btn-sm"
 															value={cdnUrl}
-															aria-label={`Load this repository at ${cdnUrl}`}
-															readonly
-														/>
-														<div class="input-group-button">
-															<clipboard-copy
-																class="btn btn-sm"
-																value={cdnUrl}
-																tabindex="0"
-																role="button"
-																aria-label="Copy to clipboard"
-															>
-																{clippy()}
-															</clipboard-copy>
-														</div>
+															tabindex="0"
+															role="button"
+															aria-label="Copy to clipboard"
+														>
+															{clippy()}
+														</clipboard-copy>
 													</div>
 												</div>
-											)
-											: (
-												<div class="flash flash-warn mt-2 jsd-flash">
-													Sadly, this package doesn't have a default file set.
-												</div>
-											)
-										}
-									</div>
-									<div class="mt-2">
-										<a
-											class="btn btn-outline get-repo-btn tooltipped tooltipped-s tooltipped-multiline"
-											href={`https://www.jsdelivr.com/package/npm/${name}`}
-											target="_blank"
-											rel="nofollow"
-											aria-label={`Open ${ownerName}/${repoName} in jsDelivr website and select the files you want to use.`}
-										>
-											Open in jsDelivr
-										</a>
-										{cdnUrl
-											? (
-												<a
-													class="btn btn-outline get-repo-btn"
-													href={`https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`}
-													rel="nofollow"
-												>
-													Download ZIP
-												</a>
-											)
-											: null
-										}
-									</div>
+											</div>
+										)
+										: (
+											<div class="flash flash-warn mt-2 jsd-flash">
+												Sadly, this package doesn't have a default file set.
+											</div>
+										)
+									}
+								</div>
+								<div class="mt-2">
+									<a
+										class="btn btn-outline get-repo-btn tooltipped tooltipped-s tooltipped-multiline"
+										href={`https://www.jsdelivr.com/package/npm/${name}`}
+										target="_blank"
+										rel="nofollow"
+										aria-label={`Open ${ownerName}/${repoName} in jsDelivr website and select the files you want to use.`}
+									>
+										Open in jsDelivr
+									</a>
+									{cdnUrl
+										? (
+											<a
+												class="btn btn-outline get-repo-btn"
+												href={`https://registry.npmjs.org/${name}/-/${name}-${version}.tgz`}
+												rel="nofollow"
+											>
+												Download ZIP
+											</a>
+										)
+										: null
+									}
 								</div>
 							</div>
 						</div>
-					</details>
-				);
+					</div>
+				</details>
+			);
 
-				const fileNavigation = document.querySelector('.file-navigation');
+			const fileNavigation = document.querySelector('.file-navigation');
 
-				if (fileNavigation) {
-					fileNavigation.append(menu);
-				}
-			} catch (error) {
-				console.error(error);
+			if (fileNavigation) {
+				fileNavigation.append(menu);
 			}
+		} catch (error) {
+			console.error(error);
 		}
 	}
+}
 
-	let getPackageNameMemo;
-	let getPackageVersionMemo;
-	let getDefaultFileMemo;
+const getPackageNameMemo = memo(getPackageName);
+const getPackageVersionMemo = memo(getPackageVersion);
+const getDefaultFileMemo = memo(getDefaultFile);
 
-	if (isGitHub()) {
-		getPackageNameMemo = memo(getPackageName);
-		getPackageVersionMemo = memo(getPackageVersion);
-		getDefaultFileMemo = memo(getDefaultFile);
-
-		init();
-		document.addEventListener('pjax:end', init);
-	}
-})();
+init();
+document.addEventListener('pjax:end', init);

--- a/src/libs/github-page-detect.js
+++ b/src/libs/github-page-detect.js
@@ -4,8 +4,6 @@
 import { getCleanPathname } from './utils';
 import { getRepoPath } from './github-utils';
 
-export const isGitHub = () => location.hostname === 'github.com';
-
 // 'user/repo'            -> true
 // 'user/repo/tree/1.0.0' -> false
 export const isRepoRootMaster = () => /^[^/]+\/[^/]+$/.test(getCleanPathname());

--- a/test/github-page-detect.js
+++ b/test/github-page-detect.js
@@ -1,19 +1,9 @@
 import chai from 'chai';
-import { isGitHub, isRepoRootMaster, isRepoRootTree } from '../src/libs/github-page-detect';
+import { isRepoRootMaster, isRepoRootTree } from '../src/libs/github-page-detect';
 
 const assert = chai.assert;
 
 describe('github-page-detect', () => {
-	describe('isGitHub', () => {
-		it('should detect if current page is GitHub', () => {
-			location.href = 'https://github.com/jquery/jquery';
-			assert.isTrue(isGitHub());
-
-			location.href = 'https://www.npmjs.com/package/jquery';
-			assert.isFalse(isGitHub());
-		});
-	});
-
 	describe('isRepoRootMaster', () => {
 		it('should detect if current page is a root of a GitHub repository on master branch', () => {
 			const masterRootRepos = [


### PR DESCRIPTION
In our [manifest file](https://github.com/jsdelivr/extension-chrome/blob/master/src/manifest.json#L20) we have configured to load GitHub's content script only for GitHub website, so we can remove `isGitHub` check from the code.